### PR TITLE
introduce new API with eager & cached decryption @hamaxx @tomazk

### DIFF
--- a/cmd/decrypt-secret/decrypt.go
+++ b/cmd/decrypt-secret/decrypt.go
@@ -8,7 +8,7 @@ import (
 )
 
 func decryptSecret(secretStr string) {
-	secret, err := secretcrypt.LoadSecret(secretStr)
+	secret, err := secretcrypt.LoadStrictSecret(secretStr)
 	if err != nil {
 		fmt.Println("Error parsing secret:", err)
 		return


### PR DESCRIPTION
The current API is renamed to StrictSecret with caching mechanism removed. As a result, decrypting a strict secret always decrypts anew and can incur a cost.

A new API is introduced replacing the current Secret, where the secret is decrypted on object initialization. Plaintext is then retrieved by calling secret.Get(). Decryption cost is incurred only once at the beginning.

pls review @hamaxx @tomazk 