### PR TITLE
 internal: make profile parameter optional for KMS. 

### DIFF
--- a/internal/kms.go
+++ b/internal/kms.go
@@ -60,7 +60,7 @@ func (c KMSCrypter) Decrypt(ciphertext Ciphertext, decryptParams DecryptParams) 
 
 	profile, ok := decryptParams["profile"]
 	if !ok {
-		return "", fmt.Errorf("Missing profile parameter!")
+		profile = "default"
 	}
 
 	ciphertextBlob, err := base64.StdEncoding.DecodeString(string(ciphertext))
@@ -88,7 +88,8 @@ func kmsClient(region string, profile string) kmsiface.KMSAPI {
 
 	clientsLock.Lock()
 	client = kms.New(session.New(), &aws.Config{
-		Region: aws.String(region),
+
+		Region:      aws.String(region),
 		Credentials: credentials.NewSharedCredentials("", profile),
 	})
 	kmsClients[region] = client

--- a/internal/kms.go
+++ b/internal/kms.go
@@ -88,7 +88,6 @@ func kmsClient(region string, profile string) kmsiface.KMSAPI {
 
 	clientsLock.Lock()
 	client = kms.New(session.New(), &aws.Config{
-
 		Region:      aws.String(region),
 		Credentials: credentials.NewSharedCredentials("", profile),
 	})

--- a/internal/kms.go
+++ b/internal/kms.go
@@ -29,7 +29,7 @@ func (c KMSCrypter) Encrypt(plaintext string, encryptParams EncryptParams) (Ciph
 
 	profile, ok := encryptParams["profile"]
 	if !ok {
-		return Ciphertext(""), nil, fmt.Errorf("Missing profile parameter!")
+		profile = "default"
 	}
 
 	keyID, ok := encryptParams["keyID"]

--- a/internal/kms_test.go
+++ b/internal/kms_test.go
@@ -51,3 +51,45 @@ func TestKms(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "mypass", plaintext)
 }
+
+func TestKmsDefaultProfile(t *testing.T) {
+	mockKMS := &MockKMSAPI{}
+	defer mockKMS.AssertExpectations(t)
+	kmsClients["myregion:default"] = mockKMS
+	kmsCrypter := KMSCrypter{}
+
+	mockKMS.On("Encrypt",
+		&kms.EncryptInput{
+			KeyId:     aws.String("mykey"),
+			Plaintext: []byte("mypass"),
+		},
+	).Return(
+		&kms.EncryptOutput{
+			CiphertextBlob: []byte("myciphertextblob"),
+		},
+		nil,
+	)
+	secret, myDecryptParams, err := kmsCrypter.Encrypt("mypass", map[string]string{
+		"region": "myregion",
+		"keyID":  "mykey",
+	})
+	assert.Equal(t, myDecryptParams, DecryptParams{
+		"region": "myregion",
+	})
+	assert.Nil(t, err)
+
+	mockKMS.On("Decrypt",
+		&kms.DecryptInput{
+			CiphertextBlob: []byte("myciphertextblob"),
+		},
+	).Return(
+		&kms.DecryptOutput{
+			Plaintext: []byte("mypass"),
+		},
+		nil,
+	)
+
+	plaintext, err := kmsCrypter.Decrypt(secret, myDecryptParams)
+	assert.Nil(t, err)
+	assert.Equal(t, "mypass", plaintext)
+}


### PR DESCRIPTION
Support for AWS KMS profiles broke existing usages. This PR fixes it by making profile optional, defaulting to "default" profile.