### PR TITLE
Undo the usage of shared credentials for AWS KMS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # go-secretcrypt
 
-[![Circle CI](https://circleci.com/gh/Zemanta/go-secretcrypt.svg?style=svg)](https://circleci.com/gh/Zemanta/go-secretcrypt)
-[![GoDoc](https://godoc.org/github.com/Zemanta/go-secretcrypt?status.svg)](https://godoc.org/github.com/Zemanta/go-secretcrypt)
-
-Utility for keeping your secrets encrypted. Also has a [Python version](https://github.com/Zemanta/py-secretcrypt).
+Utility for keeping your secrets encrypted.
 
 For example, you have the following TOML (or any format whose decoder supports TextUnmarshaler interface for custom values) configuration file
 
@@ -67,15 +64,13 @@ if err != nil {
 
 ## KMS
 The KMS option uses AWS Key Management Service. When encrypting and decrypting
-KMS secrets, you need to provide which AWS region and which AWS profile the is to be or was encrypted
-on, but it defaults to `us-east-1` and `default` respectively.
+KMS secrets, you need to provide which AWS region the is to be or was encrypted
+on, but it defaults to `us-east-1`.
 
-So if you use a custom region and/or custom profile, you must provide it to secretcrypt:
+So if you use a custom region, you must provide it to secretcrypt:
 
 ```bash
 encrypt-secret kms --region us-west-1 alias/MyKey
-encrypt-secret kms --profile second alias/MyKey
-encrypt-secret kms --region us-west-1 --profile second alias/MyKey
 ```
 
 ## Local encryption
@@ -85,10 +80,3 @@ It generates a local key in your %USER_DATA_DIR%
 be accidentally committed to CVS.
 
 It then uses that key to symmetrically encrypt and decrypt your secrets.
-
-## Password encryption - interactive only
-
-The password encryption mode should not be used in your application - it is
-meant for easily sharing secrets among developers. It interactively prompts
-the user for a password when encrypting the secret. When decrypting, it
-prompts for the password again.

--- a/README.md
+++ b/README.md
@@ -67,15 +67,12 @@ if err != nil {
 
 ## KMS
 The KMS option uses AWS Key Management Service. When encrypting and decrypting
-KMS secrets, you need to provide which AWS region and which AWS profile the is to be or was encrypted
-on, but it defaults to `us-east-1` and `default` respectively.
+KMS secrets, you need to provide the AWS region used for encrypting, the default being `us-east-1`.
 
-So if you use a custom region and/or custom profile, you must provide it to secretcrypt:
+So if you use a custom region, you must provide it to secretcrypt:
 
 ```bash
 encrypt-secret kms --region us-west-1 alias/MyKey
-encrypt-secret kms --profile second alias/MyKey
-encrypt-secret kms --region us-west-1 --profile second alias/MyKey
 ```
 
 ## Local encryption

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # go-secretcrypt
 
-Utility for keeping your secrets encrypted.
+[![Circle CI](https://circleci.com/gh/Zemanta/go-secretcrypt.svg?style=svg)](https://circleci.com/gh/Zemanta/go-secretcrypt)
+[![GoDoc](https://godoc.org/github.com/Zemanta/go-secretcrypt?status.svg)](https://godoc.org/github.com/Zemanta/go-secretcrypt)
+
+Utility for keeping your secrets encrypted. Also has a [Python version](https://github.com/Zemanta/py-secretcrypt).
 
 For example, you have the following TOML (or any format whose decoder supports TextUnmarshaler interface for custom values) configuration file
 
@@ -64,13 +67,15 @@ if err != nil {
 
 ## KMS
 The KMS option uses AWS Key Management Service. When encrypting and decrypting
-KMS secrets, you need to provide which AWS region the is to be or was encrypted
-on, but it defaults to `us-east-1`.
+KMS secrets, you need to provide which AWS region and which AWS profile the is to be or was encrypted
+on, but it defaults to `us-east-1` and `default` respectively.
 
-So if you use a custom region, you must provide it to secretcrypt:
+So if you use a custom region and/or custom profile, you must provide it to secretcrypt:
 
 ```bash
 encrypt-secret kms --region us-west-1 alias/MyKey
+encrypt-secret kms --profile second alias/MyKey
+encrypt-secret kms --region us-west-1 --profile second alias/MyKey
 ```
 
 ## Local encryption
@@ -80,3 +85,10 @@ It generates a local key in your %USER_DATA_DIR%
 be accidentally committed to CVS.
 
 It then uses that key to symmetrically encrypt and decrypt your secrets.
+
+## Password encryption - interactive only
+
+The password encryption mode should not be used in your application - it is
+meant for easily sharing secrets among developers. It interactively prompts
+the user for a password when encrypting the secret. When decrypting, it
+prompts for the password again.

--- a/cmd/decrypt-secret/decrypt.go
+++ b/cmd/decrypt-secret/decrypt.go
@@ -4,17 +4,15 @@ import (
 	"fmt"
 
 	"github.com/Zemanta/go-secretcrypt"
-	"github.com/Zemanta/go-secretcrypt/internal"
 	"github.com/docopt/docopt-go"
 )
 
-func decryptSecret(secretStr string, decryptParams internal.DecryptParams) {
+func decryptSecret(secretStr string) {
 	secret, err := secretcrypt.LoadStrictSecret(secretStr)
 	if err != nil {
 		fmt.Println("Error parsing secret:", err)
 		return
 	}
-	secret.AppendParameters(decryptParams)
 
 	plaintext, err := secret.Decrypt()
 	if err != nil {
@@ -36,8 +34,5 @@ Options:
 `
 	arguments, _ := docopt.Parse(usage, nil, true, "0.1", false)
 
-	var decryptParams = make(internal.DecryptParams)
-	decryptParams["profile"] = arguments["--profile"].(string)
-
-	decryptSecret(arguments["<secret>"].(string), decryptParams)
+	decryptSecret(arguments["<secret>"].(string))
 }

--- a/cmd/encrypt-secret/encrypt.go
+++ b/cmd/encrypt-secret/encrypt.go
@@ -34,7 +34,6 @@ Usage:
 Options:
   --help
   --region=<region_name>    AWS Region Name [default: us-east-1]
-  --profile=<profile>	    AWS Profile Name [default: default]
   --multiline               Multiline input (read stdin bytes until EOF)
 `
 
@@ -45,7 +44,6 @@ Options:
 	if arguments["kms"].(bool) {
 		crypter = internal.CryptersMap["kms"]
 		encryptParams["region"] = arguments["--region"].(string)
-		encryptParams["profile"] = arguments["--profile"].(string)
 		encryptParams["keyID"] = arguments["<key_id>"].(string)
 	} else if arguments["local"].(bool) {
 		crypter = internal.CryptersMap["local"]

--- a/internal/kms_test.go
+++ b/internal/kms_test.go
@@ -11,51 +11,7 @@ import (
 func TestKms(t *testing.T) {
 	mockKMS := &MockKMSAPI{}
 	defer mockKMS.AssertExpectations(t)
-	kmsClients["myregion:myprofile"] = mockKMS
-	kmsCrypter := KMSCrypter{}
-
-	mockKMS.On("Encrypt",
-		&kms.EncryptInput{
-			KeyId:     aws.String("mykey"),
-			Plaintext: []byte("mypass"),
-		},
-	).Return(
-		&kms.EncryptOutput{
-			CiphertextBlob: []byte("myciphertextblob"),
-		},
-		nil,
-	)
-	secret, myDecryptParams, err := kmsCrypter.Encrypt("mypass", map[string]string{
-		"region":  "myregion",
-		"profile": "myprofile",
-		"keyID":   "mykey",
-	})
-	assert.Equal(t, myDecryptParams, DecryptParams{
-		"region": "myregion",
-	})
-	assert.Nil(t, err)
-
-	mockKMS.On("Decrypt",
-		&kms.DecryptInput{
-			CiphertextBlob: []byte("myciphertextblob"),
-		},
-	).Return(
-		&kms.DecryptOutput{
-			Plaintext: []byte("mypass"),
-		},
-		nil,
-	)
-	myDecryptParams["profile"] = "myprofile"
-
-	plaintext, err := kmsCrypter.Decrypt(secret, myDecryptParams)
-	assert.Nil(t, err)
-	assert.Equal(t, "mypass", plaintext)
-}
-
-func TestKmsDefaultProfile(t *testing.T) {
-	mockKMS := &MockKMSAPI{}
-	defer mockKMS.AssertExpectations(t)
-	kmsClients["myregion:default"] = mockKMS
+	kmsClients["myregion"] = mockKMS
 	kmsCrypter := KMSCrypter{}
 
 	mockKMS.On("Encrypt",


### PR DESCRIPTION
The switch to use shared credentials (~/.aws folder) broke the existing usages of credentials. I believe it is best we leave it to AWS SDK to decide how to authenticate since it supports many different methods raging from IAM roles to environment variables.

According to Amazon docs, you can set AWS_PROFILE when wanting to work with non-default profile.

More about it here: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html