### PR TITLE
Store the secret text when unmarshaling

### DIFF
--- a/secret.go
+++ b/secret.go
@@ -114,6 +114,7 @@ func (s *Secret) UnmarshalText(text []byte) error {
 	if err != nil {
 		return err
 	}
+	s.secret = string(text)
 	s.plaintext, err = strictSecret.Decrypt()
 	return err
 }

--- a/secret_test.go
+++ b/secret_test.go
@@ -131,8 +131,7 @@ func TestSecretMarshalText(t *testing.T) {
 	text, err := secret.MarshalText()
 	assert.NoError(t, err)
 	assert.NotNil(t, text)
-	assert.Equal(t, "", string(text))
-	// assert.Equal(t, "plain:k1=v1&k2=v2:my-abc", string(text)) // TODO: check why it gets "" here
+	assert.Equal(t, "plain:k1=v1&k2=v2:my-abc", string(text))
 }
 
 func TestStrictSecretUnmarshalTextError(t *testing.T) {


### PR DESCRIPTION
We're trying to provide secrets to a hadoop job: https://github.com/Zemanta/b1/pull/6083/files#diff-8b4000d27f81e71b8f645af763ed816a385fef8ec1d110ce52e5c008b565b505R105
But all secrets get marshaled to an empty value, because the secret text is not stored.