### PR TITLE
Make MarshalText a value receiver

### DIFF
--- a/secret.go
+++ b/secret.go
@@ -28,7 +28,7 @@ func (s *StrictSecret) Decrypt() (string, error) {
 }
 
 // MarshalText marshalls the secret into its textual representation.
-func (s *StrictSecret) MarshalText() (text []byte, err error) {
+func (s StrictSecret) MarshalText() (text []byte, err error) {
 	return []byte(fmt.Sprintf(
 		"%s:%s:%s",
 		s.crypter.Name(),
@@ -103,7 +103,7 @@ func (s Secret) Get() string {
 }
 
 // MarshalText marshalls the secret into its textual representation.
-func (s *Secret) MarshalText() (text []byte, err error) {
+func (s Secret) MarshalText() (text []byte, err error) {
 	return []byte(s.secret), nil
 }
 


### PR DESCRIPTION
I think we shouldn't require a pointer to marshal the secret.
Here https://github.com/Zemanta/b1/blob/2b5d7e4beddb28c24ffadfefe0ed56419294e9d9/centralapi/jobs/serverlogstats/serverlogstats.go#L106 without using a reference it gets marshaled to `{}`.

However, this isn't urgent, it can get released during the next dependency bump.